### PR TITLE
handle WeeklyPolicy numerical parameters consistently, eg. 1=Monday

### DIFF
--- a/tinylog/src/main/java/org/pmw/tinylog/policies/WeeklyPolicy.java
+++ b/tinylog/src/main/java/org/pmw/tinylog/policies/WeeklyPolicy.java
@@ -71,7 +71,7 @@ public final class WeeklyPolicy extends AbstractTimeBasedPolicy {
 	}
 
 	private static int convert(final Calendar calendar, final int dayOfWeek) {
-		return (calendar.getFirstDayOfWeek() - 1 + dayOfWeek - 1) % 7 + 1;
+		return (Calendar.MONDAY - 1 + dayOfWeek - 1) % 7 + 1;
 	}
 
 	private static Calendar createCalendar(final String dayOfWeek) {

--- a/tinylog/src/main/java/org/pmw/tinylog/policies/WeeklyPolicy.java
+++ b/tinylog/src/main/java/org/pmw/tinylog/policies/WeeklyPolicy.java
@@ -35,7 +35,7 @@ public final class WeeklyPolicy extends AbstractTimeBasedPolicy {
 	 * Trigger the first rollover at 00:00 at the defined day of week.
 	 * 
 	 * @param dayOfWeek
-	 *            Day of week (between 1..7) for rollover
+	 *            Day of week (between 1..7) for rollover (1=Monday, 7=Sunday)
 	 * @throws IllegalArgumentException
 	 *             if dayOfWeek is out of range (1..7)
 	 */


### PR DESCRIPTION
Based on the tests WeeklyPolicy numerical parameters are interpreted as 1 being Monday. I have assumed that this is the intended operation and fixed WeeklyPolicy accordingly. (If not, then the tests should be updated to handle the default and numerical constructor cases correctly)

In my system Calendar.MONDAY==2 (Calendar.SUNDAY==1), so the tests failed.

The source of the problem was the inconsistent handling of numerical parameters - it rebased the parameters in the convert method based on calendar.getFirstDayOfWeek(), which was Sunday for me (1 == Calendar.SUNDAY).

I have changed to use Calendar.MONDAY as  base of calculations, this way the tests run correctly on my system.

System: Java(TM) SE Runtime Environment (build 1.8.0_51-b16), Windows 10 64 bit
Locale.getDefault(): en_us