### PR TITLE
Strip anonymous part from classnames. Fixes #10.

### DIFF
--- a/tests/src/org/pmw/tinylog/LoggerTest.java
+++ b/tests/src/org/pmw/tinylog/LoggerTest.java
@@ -572,6 +572,17 @@ public class LoggerTest extends AbstractTest {
 		assertEquals(Level.INFO, logEntry.getLevel());
 		assertEquals(LoggerTest.class.getName(), logEntry.getClassName());
 
+		/* Test logging of anonymous class. Anonymous part of classname gets stripped */
+
+		new Object() {
+			{
+				Logger.info("Hello!");
+			}
+		};
+
+		logEntry = writer.consumeLogEntry();
+		assertEquals(LoggerTest.class.getName(), logEntry.getClassName());
+
 		/* Test logging of plain texts */
 
 		writer = new StoreWriter(LogEntryValue.LEVEL, LogEntryValue.CLASS, LogEntryValue.MESSAGE);
@@ -785,6 +796,12 @@ public class LoggerTest extends AbstractTest {
 		assertEquals("MyClass" + EnvironmentHelper.getNewLine(), logEntry.getRenderedLogEntry());
 
 		Logger.output(new StackTraceElement("MyClass", "unknown", "unknown", -1), Level.INFO, null, "Hello", new Object[0]);
+
+		logEntry = writer.consumeLogEntry();
+		assertEquals("MyClass", logEntry.getClassName());
+		assertEquals("MyClass" + EnvironmentHelper.getNewLine(), logEntry.getRenderedLogEntry());
+
+		Logger.output(new StackTraceElement("MyClass$1", "unknown", "unknown", -1), Level.INFO, null, "Hello", new Object[0]);
 
 		logEntry = writer.consumeLogEntry();
 		assertEquals("MyClass", logEntry.getClassName());

--- a/tinylog/src/org/pmw/tinylog/Logger.java
+++ b/tinylog/src/org/pmw/tinylog/Logger.java
@@ -625,7 +625,7 @@ public final class Logger {
 		Thread thread = null;
 		Map<String, String> context = null;
 		StackTraceElement stackTraceElement = createdStackTraceElement;
-		String fullyQualifiedClassName = null;
+		String className = null;
 		String method = null;
 		String filename = null;
 		int line = -1;
@@ -654,7 +654,11 @@ public final class Logger {
 						boolean onlyClassName = currentConfiguration.getRequiredStackTraceInformation(level) == StackTraceInformation.CLASS_NAME;
 						stackTraceElement = getStackTraceElement(strackTraceDeep, onlyClassName);
 					}
-					fullyQualifiedClassName = stackTraceElement.getClassName();
+					className = stackTraceElement.getClassName();
+					int dollarIndex = className.indexOf("$");
+					if (dollarIndex != -1) {
+						className = className.substring(0, dollarIndex);
+					}
 					break;
 
 				case METHOD:
@@ -694,7 +698,7 @@ public final class Logger {
 		}
 
 		for (int i = 0; i < entries.length; ++i) {
-			LogEntry logEntry = new LogEntry(now, processId, thread, context, fullyQualifiedClassName, method, filename, line, level, renderedMessage, exception);
+			LogEntry logEntry = new LogEntry(now, processId, thread, context, className, method, filename, line, level, renderedMessage, exception);
 			List<Token> formatTokensOfWriter = formatTokens[i];
 			if (formatTokensOfWriter != null) {
 				StringBuilder builder = new StringBuilder(exception == null ? 256 : 1024);


### PR DESCRIPTION
Backport from master, cherry picked from commit
449a5be71ad7ccaad50f64de654647228ef4612f.