### PR TITLE
Simplify .gitignore, exclude IntelliJ files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-/.*/*
-/*/.settings
-/*/target
+.*
+target
+*.iml


### PR DESCRIPTION
'name' matches in all directories. '/name' matches only entries in the root folder.