### PR TITLE
Update class name formatting to cover more cases.

### DIFF
--- a/tests/src/org/pmw/tinylog/LoggerTest.java
+++ b/tests/src/org/pmw/tinylog/LoggerTest.java
@@ -819,11 +819,71 @@ public class LoggerTest extends AbstractTest {
 		assertEquals("MyClass$InnerClass", logEntry.getClassName());
 		assertEquals("MyClass$InnerClass" + EnvironmentHelper.getNewLine(), logEntry.getRenderedLogEntry());
 
+		Logger.output(new StackTraceElement("MyClass$I$1", "unknown", "unknown", -1), Level.INFO, null, "Hello", new Object[0]);
+
+		logEntry = writer.consumeLogEntry();
+		assertEquals("MyClass$I", logEntry.getClassName());
+		assertEquals("MyClass$I" + EnvironmentHelper.getNewLine(), logEntry.getRenderedLogEntry());
+
+		Logger.output(new StackTraceElement("MyClass$I", "unknown", "unknown", -1), Level.INFO, null, "Hello", new Object[0]);
+
+		logEntry = writer.consumeLogEntry();
+		assertEquals("MyClass$I", logEntry.getClassName());
+		assertEquals("MyClass$I" + EnvironmentHelper.getNewLine(), logEntry.getRenderedLogEntry());
+
 		Logger.output(new StackTraceElement("MyClass$InnerClass$2", "unknown", "unknown", -1), Level.INFO, null, "Hello", new Object[0]);
 
 		logEntry = writer.consumeLogEntry();
 		assertEquals("MyClass$InnerClass", logEntry.getClassName());
 		assertEquals("MyClass$InnerClass" + EnvironmentHelper.getNewLine(), logEntry.getRenderedLogEntry());
+
+		Logger.output(new StackTraceElement("scalaPackageObject$", "unknown", "unknown", -1), Level.INFO, null, "Hello", new Object[0]);
+
+		logEntry = writer.consumeLogEntry();
+		assertEquals("scalaPackageObject", logEntry.getClassName());
+		assertEquals("scalaPackageObject" + EnvironmentHelper.getNewLine(), logEntry.getRenderedLogEntry());
+
+		Logger.output(new StackTraceElement("ScalaObject$", "unknown", "unknown", -1), Level.INFO, null, "Hello", new Object[0]);
+
+		logEntry = writer.consumeLogEntry();
+		assertEquals("ScalaObject", logEntry.getClassName());
+		assertEquals("ScalaObject" + EnvironmentHelper.getNewLine(), logEntry.getRenderedLogEntry());
+
+		Logger.output(new StackTraceElement("ScalaTrait$class", "unknown", "unknown", -1), Level.INFO, null, "Hello", new Object[0]);
+
+		logEntry = writer.consumeLogEntry();
+		assertEquals("ScalaTrait", logEntry.getClassName());
+		assertEquals("ScalaTrait" + EnvironmentHelper.getNewLine(), logEntry.getRenderedLogEntry());
+
+		Logger.output(new StackTraceElement("groovyClosure$_runImpl_closure_1", "unknown", "unknown", -1), Level.INFO, null, "Hello", new Object[0]);
+
+		logEntry = writer.consumeLogEntry();
+		assertEquals("groovyClosure", logEntry.getClassName());
+		assertEquals("groovyClosure" + EnvironmentHelper.getNewLine(), logEntry.getRenderedLogEntry());
+
+		Logger.output(new StackTraceElement("$", "unknown", "unknown", -1), Level.INFO, null, "Hello", new Object[0]);
+
+		logEntry = writer.consumeLogEntry();
+		assertEquals("", logEntry.getClassName());
+		assertEquals("" + EnvironmentHelper.getNewLine(), logEntry.getRenderedLogEntry());
+
+		Logger.output(new StackTraceElement("A", "unknown", "unknown", -1), Level.INFO, null, "Hello", new Object[0]);
+
+		logEntry = writer.consumeLogEntry();
+		assertEquals("A", logEntry.getClassName());
+		assertEquals("A" + EnvironmentHelper.getNewLine(), logEntry.getRenderedLogEntry());
+
+		Logger.output(new StackTraceElement("A$", "unknown", "unknown", -1), Level.INFO, null, "Hello", new Object[0]);
+
+		logEntry = writer.consumeLogEntry();
+		assertEquals("A", logEntry.getClassName());
+		assertEquals("A" + EnvironmentHelper.getNewLine(), logEntry.getRenderedLogEntry());
+
+		Logger.output(new StackTraceElement("a$", "unknown", "unknown", -1), Level.INFO, null, "Hello", new Object[0]);
+
+		logEntry = writer.consumeLogEntry();
+		assertEquals("a", logEntry.getClassName());
+		assertEquals("a" + EnvironmentHelper.getNewLine(), logEntry.getRenderedLogEntry());
 	}
 
 	/**

--- a/tinylog/src/org/pmw/tinylog/Logger.java
+++ b/tinylog/src/org/pmw/tinylog/Logger.java
@@ -655,9 +655,16 @@ public final class Logger {
 						stackTraceElement = getStackTraceElement(strackTraceDeep, onlyClassName);
 					}
 					className = stackTraceElement.getClassName();
-					for (int index = className.indexOf("$", 0); index != -1 && index < className.length() - 1; index = className.indexOf('$', index + 2)) {
+					for (int index = className.indexOf("$", 0); index != -1; index = className.indexOf('$', index + 2)) {
+						// trailing dollar sign
+						if (index >= className.length() -1) {
+							className = className.substring(0, index);
+							break;
+						}
+
 						char firstLetter = className.charAt(index + 1);
-						if ((firstLetter >= '0' && firstLetter <= '9') || firstLetter <= '$') {
+						// first letter after dollar sign is not an uppercase letter of an inner class
+						if (firstLetter < 'A' || firstLetter > 'Z') {
 							className = className.substring(0, index);
 							break;
 						}


### PR DESCRIPTION
Here's a first iteration. Trying to cover a lot of (edge) cases. Do you know if extracting the calls to _classname.length()_ would have a (positive) impact on the performance?

The tests are copied and pasted (okay for test code I guess). I'd be tempted to extract a method like _verifyTrimmedClassName_ and have a new test with a lot of calls of the form _verifyTrimmedClassName("MyClass$Inner$1", "MyClass$Inner")_, so that the new test reads like a specification. But I don't want to introduce a new style (which I'm learning through Scala(Test) right now) into existing code.