### PR TITLE
SLF4J Exception Handling

### DIFF
--- a/slf4j-binding/src/main/java/org/slf4j/impl/TinylogBridge.java
+++ b/slf4j-binding/src/main/java/org/slf4j/impl/TinylogBridge.java
@@ -55,12 +55,12 @@ final class TinylogBridge {
 	 * @param level
 	 *            Logging level of log entry
 	 * @param message
-	 *            Formated text for the log entry
+	 *            Formatted text for the log entry
 	 * @param arguments
 	 *            Arguments for the text message
 	 */
 	public static void log(final Level level, final String message, final Object... arguments) {
-		LogEntryForwarder.forward(2, level, message, arguments);
+		LogEntryForwarder.forward(2, level, getLastElementIfThrowable(level, arguments), message, arguments);
 	}
 
 	/**
@@ -75,6 +75,23 @@ final class TinylogBridge {
 	 */
 	public static void log(final Level level, final String message, final Throwable throwable) {
 		LogEntryForwarder.forward(2, level, throwable, message);
+	}
+
+	/**
+	 * If the message being logged is of type ERROR the last object needs to be test to see if it is Throwable,
+	 * if not no further action is needed, if so the throwable needs to be tracked so that the stacktrace is logged.
+	 *
+	 * @param level
+	 *            Logging level to test
+	 * @param arguments
+	 *            Arguments for the text message
+	 * @return The Throwable if the last element is Throwable otherwise null.
+	 */
+	private static Throwable getLastElementIfThrowable(final Level level, final Object... arguments) {
+		if (level == Level.ERROR && arguments[arguments.length - 1] instanceof Throwable) {
+			return (Throwable) arguments[arguments.length - 1];
+		}
+		return null;
 	}
 
 }

--- a/slf4j-binding/src/test/java/org/slf4j/impl/TinylogLoggerTest.java
+++ b/slf4j-binding/src/test/java/org/slf4j/impl/TinylogLoggerTest.java
@@ -463,6 +463,13 @@ public class TinylogLoggerTest extends AbstractTest {
 		assertEquals(Level.ERROR, logEntry.getLevel());
 		assertEquals("Failed", logEntry.getMessage());
 		assertEquals(exception, logEntry.getException());
+
+		exception = new Exception();
+		logger.error(MARKER, "Failed {}", "Here", exception);
+		logEntry = writer.consumeLogEntry();
+		assertEquals(Level.ERROR, logEntry.getLevel());
+		assertEquals("Failed Here", logEntry.getMessage());
+		assertEquals(exception, logEntry.getException());
 	}
 
 }


### PR DESCRIPTION
Ensure that the stack trace is logged when the last argument to `log.error` is Throwable.

The current example from SLF4J does not print a stack trace when logging an exception unless there are no parameterized arguments.

http://www.slf4j.org/faq.html#paramException

Fails:
```java
String s = "Hello world";
try {
  Integer i = Integer.valueOf(s);
} catch (NumberFormatException e) {
  logger.error("Failed to format {}", s, e);
}
```

Works
```java
String s = "Hello world";
try {
  Integer i = Integer.valueOf(s);
} catch (NumberFormatException e) {
  logger.error("Failed to format", e);
}
```